### PR TITLE
Add export_bundle and download_bundle methods

### DIFF
--- a/lib/crowdin-api/api_resources/bundles.rb
+++ b/lib/crowdin-api/api_resources/bundles.rb
@@ -36,6 +36,38 @@ module Crowdin
         Web::SendRequest.new(request).perform
       end
 
+      # @param query [Hash] Request Body
+      # * {https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.exports.post  API Documentation}
+      # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.bundles.exports.post  Enterprise API Documentation}
+      def export_bundle(query = {}, project_id = config.project_id, bundle_id)
+        bundle_id  || raise_parameter_is_required_error(:bundle_id)
+        project_id || raise_project_id_is_required_error
+        
+        request = Web::Request.new(
+          connection,
+          :post,
+          "#{config.target_api_url}/projects/#{project_id}/bundles/#{bundle_id}/exports",
+          { params: query }
+        )
+        Web::SendRequest.new(request).perform
+      end
+
+      # @param bundle_id [Integer] Bundle ID
+      # * {https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.exports.download.get  API Documentation}
+      # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.bundles.exports.download.get  Enterprise API Documentation}
+      def download_bundle(project_id = config.project_id, bundle_id, export_id)
+        bundle_id  || raise_parameter_is_required_error(:bundle_id)
+        export_id  || raise_parameter_is_required_error(:export_id)        
+        project_id || raise_project_id_is_required_error
+
+        request = Web::Request.new(
+          connection,
+          :get,
+          "#{config.target_api_url}/projects/#{project_id}/bundles/#{bundle_id}/exports/#{export_id}/download"
+        )
+        Web::SendRequest.new(request).perform
+      end
+            
       # @param bundle_id [Integer] Bundle ID
       # * {https://developer.crowdin.com/api/v2/#operation/api.projects.bundles.get  API Documentation}
       # * {https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.bundles.get  Enterprise API Documentation}

--- a/spec/api_resources/bundles_spec.rb
+++ b/spec/api_resources/bundles_spec.rb
@@ -18,6 +18,22 @@ describe Crowdin::ApiResources::Bundles do
       end
     end
 
+    describe '#export_bundle' do
+      it 'when request are valid', :default do
+        stub_request(:post, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/bundles/#{bundle_id}/exports")
+        export_bundle = @crowdin.export_bundle({ name: '', format: '', sourcePatterns: [], exportPattern: '' }, project_id, bundle_id)
+        expect(export_bundle).to eq(200)
+      end
+    end
+    
+    describe '#download_bundle' do
+      it 'when request are valid', :default do
+        stub_request(:get, "https://api.crowdin.com/#{target_api_url}/projects/#{project_id}/bundles/#{bundle_id}/exports/#{export_id}/download")
+        download_bundle = @crowdin.download_bundle(project_id, bundle_id, export_id)
+        expect(download_bundle).to eq(200)
+      end
+    end
+        
     describe '#get_bundle' do
       let(:bundle_id) { 1 }
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -88,4 +88,10 @@ describe 'Crowdin Client' do
       expect { @crowdin.fetch_all(:add_bundle).to raise_error(Crowdin::Errors::FetchAllProcessingError) }
     end
   end
+  
+    describe 'Crowdin Client fetch_all' do
+    it 'should raise error if fetch_all is called for unsupported methods' do
+      expect { @crowdin.fetch_all(:export_bundle).to raise_error(Crowdin::Errors::FetchAllProcessingError) }
+    end
+  end
 end


### PR DESCRIPTION
## Description

This adds two not-yet-supported CrowdIn API bundle operation methods to `crowdin-api-client-ruby`, which supply the ability to export a defined bundle and then to download the exported bundle.

## Motivation

**Target File Bundles** are how **CrowdIn** allows the export of translation sets in different string formats. In order to be able to use one source file or source "vault" to be able to export either iOS (.string) or Android (.xml) string formats, we first define the output bundle types on **CrowdIn** and then download them manually. In order to be able to make this part of Ruby automation, we need to add support for these new API methods to `crowdin-api-client-ruby`.

## Unit Testing

I added the test specs in their preferred format, on the theory that we may want to submit a PR to the main project at some point.

## Manual Testing

I have used these methods and they work.

## Ready to Review

All of the below must pass 100% before marking the PR as Ready to Review.  Any exceptions should be explained here or in the PR comments.

- ✅  All pre-submit unit tests pass
- ✅  All linter and static analysis warnings addressed
- ✅  All temporary testing code removed

## Before Merging

1. Merge the base branch (usually develop) into this branch first
2. Rerun all formatters, linters, and pre-sbmit unit tests and ensure all pass
